### PR TITLE
Allow usernames with dots

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :users, only: [:index, :show, :edit, :update]
+  resources :users, only: [:index, :show, :edit, :update], constraints: { id: /[^\/]+/ }
   resources :github_users, only: [:index, :show]
 
   root 'dashboard#index'

--- a/cookbook/recipes/ruby.rb
+++ b/cookbook/recipes/ruby.rb
@@ -31,21 +31,3 @@ rvm_gemset node['github_connector']['ruby_gemset'] do
   user node['github_connector']['user']
   ruby_string node['github_connector']['ruby_version']
 end
-
-# Create an alias that remains consistent across version/gemset changes
-execute 'github-connector-alias' do
-  rvm_cmd = "/home/#{node['github_connector']['user']}/.rvm/bin/rvm"
-  rvm_alias = node['github_connector']['rvm_alias']
-  ruby_string = "#{node['github_connector']['ruby_version']}@#{node['github_connector']['ruby_gemset']}"
-
-  user node['github_connector']['user']
-  group node['github_connector']['group']
-  command "#{rvm_cmd} alias create #{rvm_alias} #{ruby_string}"
-  not_if do
-    cmd = Mixlib::ShellOut.new("#{rvm_cmd} alias show #{rvm_alias}")
-    cmd.run_command
-    !cmd.error? && (cmd.stdout.strip == ruby_string)
-  end
-  notifies :reload, 'service[github-connector-web]', :delayed
-  notifies :restart, 'service[github-connector-worker]', :delayed
-end

--- a/cookbook/recipes/server.rb
+++ b/cookbook/recipes/server.rb
@@ -55,6 +55,24 @@ git 'github-connector' do
 end
 
 
+# Create an alias that remains consistent across version/gemset changes
+execute 'github-connector-alias' do
+  rvm_cmd = "/home/#{node['github_connector']['user']}/.rvm/bin/rvm"
+  rvm_alias = node['github_connector']['rvm_alias']
+  ruby_string = "#{node['github_connector']['ruby_version']}@#{node['github_connector']['ruby_gemset']}"
+
+  user node['github_connector']['user']
+  group node['github_connector']['group']
+  command "#{rvm_cmd} alias create #{rvm_alias} #{ruby_string}"
+  not_if do
+    cmd = Mixlib::ShellOut.new("#{rvm_cmd} alias show #{rvm_alias}")
+    cmd.run_command
+    !cmd.error? && (cmd.stdout.strip == ruby_string)
+  end
+  notifies :reload, 'service[github-connector-web]', :delayed
+  notifies :restart, 'service[github-connector-worker]', :delayed
+end
+
 #
 # Configuration files
 #

--- a/cookbook/recipes/upstart.rb
+++ b/cookbook/recipes/upstart.rb
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 
+directory "#{node['github_connector']['install_dir']}/tmp/sockets" do
+  owner node['github_connector']['user']
+  group node['github_connector']['group']
+  mode 0755
+end
+
 template "/etc/init/github-connector-web.conf" do
   source 'upstart-github-connector-web.conf.erb'
   mode 0644


### PR DESCRIPTION
By default, rails uses dots to delimit the format of the urls. Since
this app uses usernames in urls and a lot of companies have dots in
their username schemes, it is necessary to allow this.
